### PR TITLE
Improvements to Miner & Validator

### DIFF
--- a/miner.py
+++ b/miner.py
@@ -7,6 +7,7 @@ from typing import Tuple
 
 from protocol import Dummy
 
+
 class Miner:
     def __init__(self):
         self.config = self.get_config()
@@ -17,9 +18,15 @@ class Miner:
         # Set up the configuration parser
         parser = argparse.ArgumentParser()
         # TODO: Add your custom miner arguments to the parser.
-        parser.add_argument('--custom', default='my_custom_value', help='Adds a custom value to the parser.')
+        parser.add_argument(
+            "--custom",
+            default="my_custom_value",
+            help="Adds a custom value to the parser.",
+        )
         # Adds override arguments for network and netuid.
-        parser.add_argument('--netuid', type=int, default=1, help="The chain subnet uid.")
+        parser.add_argument(
+            "--netuid", type=int, default=1, help="The chain subnet uid."
+        )
         # Adds subtensor specific arguments.
         bt.subtensor.add_args(parser)
         # Adds logging specific arguments.
@@ -37,7 +44,7 @@ class Miner:
                 config.wallet.name,
                 config.wallet.hotkey_str,
                 config.netuid,
-                'miner',
+                "miner",
             )
         )
         # Ensure the directory for logging exists.
@@ -47,7 +54,9 @@ class Miner:
     def setup_logging(self):
         # Activate Bittensor's logging with the set configurations.
         bt.logging(config=self.config, logging_dir=self.config.full_path)
-        bt.logging.info(f"Running miner for subnet: {self.config.netuid} on network: {self.config.subtensor.network} with config:")
+        bt.logging.info(
+            f"Running miner for subnet: {self.config.netuid} on network: {self.config.subtensor.network} with config:"
+        )
         bt.logging.info(self.config)
 
     def setup_bittensor_objects(self):
@@ -67,25 +76,35 @@ class Miner:
         bt.logging.info(f"Metagraph: {self.metagraph}")
 
         if self.wallet.hotkey.ss58_address not in self.metagraph.hotkeys:
-            bt.logging.error(f"\nYour miner: {self.wallet} is not registered to chain connection: {self.subtensor} \nRun 'btcli register' and try again.")
+            bt.logging.error(
+                f"\nYour miner: {self.wallet} is not registered to chain connection: {self.subtensor} \nRun 'btcli register' and try again."
+            )
             exit()
         else:
             # Each miner gets a unique identity (UID) in the network.
-            self.my_subnet_uid = self.metagraph.hotkeys.index(self.wallet.hotkey.ss58_address)
+            self.my_subnet_uid = self.metagraph.hotkeys.index(
+                self.wallet.hotkey.ss58_address
+            )
             bt.logging.info(f"Running miner on uid: {self.my_subnet_uid}")
 
     def blacklist_fn(self, synapse: Dummy) -> Tuple[bool, str]:
         # Ignore requests from unrecognized entities.
         if synapse.dendrite.hotkey not in self.metagraph.hotkeys:
-            bt.logging.trace(f'Blacklisting unrecognized hotkey {synapse.dendrite.hotkey}')
+            bt.logging.trace(
+                f"Blacklisting unrecognized hotkey {synapse.dendrite.hotkey}"
+            )
             return True, None
-        bt.logging.trace(f'Not blacklisting recognized hotkey {synapse.dendrite.hotkey}')
+        bt.logging.trace(
+            f"Not blacklisting recognized hotkey {synapse.dendrite.hotkey}"
+        )
         return False, None
 
     def dummy(self, synapse: Dummy) -> Dummy:
         # Simple logic: return the input value multiplied by 2.
         synapse.dummy_output = synapse.dummy_input * 2
-        bt.logging.info(f"Received input: {synapse.dummy_input}, sending output: {synapse.dummy_output}")
+        bt.logging.info(
+            f"Received input: {synapse.dummy_input}, sending output: {synapse.dummy_output}"
+        )
         return synapse
 
     def setup_axon(self):
@@ -93,14 +112,16 @@ class Miner:
         self.axon = bt.axon(wallet=self.wallet, config=self.config)
 
         # Attach functions to the axon.
-        bt.logging.info(f"Attaching forward function to axon.")
+        bt.logging.info("Attaching forward function to axon.")
         self.axon.attach(
             forward_fn=self.dummy,
             blacklist_fn=self.blacklist_fn,
         )
 
         # Serve the axon.
-        bt.logging.info(f"Serving axon on network: {self.config.subtensor.network} with netuid: {self.config.netuid}")
+        bt.logging.info(
+            f"Serving axon on network: {self.config.subtensor.network} with netuid: {self.config.netuid}"
+        )
         self.axon.serve(netuid=self.config.netuid, subtensor=self.subtensor)
         bt.logging.info(f"Axon: {self.axon}")
 
@@ -120,8 +141,8 @@ class Miner:
                 if step % 60 == 0:
                     self.metagraph.sync()
                     log = (
-                        f'Block: {self.metagraph.block.item()} | '
-                        f'Incentive: {self.metagraph.I[self.my_subnet_uid]} | '
+                        f"Block: {self.metagraph.block.item()} | "
+                        f"Incentive: {self.metagraph.I[self.my_subnet_uid]} | "
                     )
                     bt.logging.info(log)
                 step += 1
@@ -129,11 +150,12 @@ class Miner:
 
             except KeyboardInterrupt:
                 self.axon.stop()
-                bt.logging.success('Miner killed by keyboard interrupt.')
+                bt.logging.success("Miner killed by keyboard interrupt.")
                 break
             except Exception as e:
                 bt.logging.error(traceback.format_exc())
                 continue
+
 
 # Run the miner.
 if __name__ == "__main__":

--- a/miner.py
+++ b/miner.py
@@ -90,7 +90,7 @@ class Miner:
 
     def setup_axon(self):
         # Build and link miner functions to the axon.
-        self.axon = bt.axon(wallet=self.wallet, port=self.config.axon.port)
+        self.axon = bt.axon(wallet=self.wallet, config=self.config)
 
         # Attach functions to the axon.
         bt.logging.info(f"Attaching forward function to axon.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-bittensor>=8.4.3
+bittensor>=8.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-bittensor>=7.4.0
+bittensor>=8.4.3

--- a/validator.py
+++ b/validator.py
@@ -44,15 +44,16 @@ class Validator:
         # Parse the config.
         config = bt.config(parser)
         # Set up logging directory.
-        config.full_path = os.path.expanduser(
-            "{}/{}/{}/netuid{}/{}".format(
-                config.logging.logging_dir,
-                config.wallet.name,
-                config.wallet.hotkey_str,
-                config.netuid,
-                "validator",
-            )
+
+        logging_path = "{}/{}/{}/netuid{}/{}".format(
+            config.logging.logging_dir,
+            config.wallet.name,
+            config.wallet.hotkey_str,
+            config.netuid,
+            "validator",
         )
+        config.full_path = os.path.expanduser(logging_path)
+
         # Ensure the logging directory exists.
         os.makedirs(config.full_path, exist_ok=True)
         return config
@@ -88,7 +89,7 @@ class Validator:
         # Connect the validator to the network.
         if self.wallet.hotkey.ss58_address not in self.metagraph.hotkeys:
             bt.logging.error(
-                f"\nYour validator: {self.wallet} is not registered to chain connection: {self.subtensor} \nRun 'btcli register' and try again."
+                f"Your validator: {self.wallet} is not registered to chain connection: {self.subtensor} \nRun 'btcli register' and try again."
             )
             exit()
         else:

--- a/validator.py
+++ b/validator.py
@@ -87,7 +87,7 @@ class Validator:
         # Connect the validator to the network.
         if self.wallet.hotkey.ss58_address not in self.metagraph.hotkeys:
             bt.logging.error(
-                f"\nYour validator: {self.wallet} is not registered to chain connection: {self.subtensor} \nRun 'btcli register' and try again."
+                f"Your validator: {self.wallet} is not registered to chain connection: {self.subtensor} \nRun 'btcli register' and try again."
             )
             exit()
         else:

--- a/validator.py
+++ b/validator.py
@@ -44,16 +44,14 @@ class Validator:
         # Parse the config.
         config = bt.config(parser)
         # Set up logging directory.
-
-        logging_path = "{}/{}/{}/netuid{}/{}".format(
-            config.logging.logging_dir,
-            config.wallet.name,
-            config.wallet.hotkey_str,
-            config.netuid,
-            "validator",
+        config.full_path = os.path.expanduser(
+            "{}/{}/{}/netuid{}/validator".format(
+                config.logging.logging_dir,
+                config.wallet.name,
+                config.wallet.hotkey_str,
+                config.netuid,
+            )
         )
-        config.full_path = os.path.expanduser(logging_path)
-
         # Ensure the logging directory exists.
         os.makedirs(config.full_path, exist_ok=True)
         return config
@@ -89,7 +87,7 @@ class Validator:
         # Connect the validator to the network.
         if self.wallet.hotkey.ss58_address not in self.metagraph.hotkeys:
             bt.logging.error(
-                f"Your validator: {self.wallet} is not registered to chain connection: {self.subtensor} \nRun 'btcli register' and try again."
+                f"\nYour validator: {self.wallet} is not registered to chain connection: {self.subtensor} \nRun 'btcli register' and try again."
             )
             exit()
         else:
@@ -149,7 +147,7 @@ class Validator:
                 if self.last_update > self.tempo + 1:
                     total = sum(self.moving_avg_scores)
                     weights = [score / total for score in self.moving_avg_scores]
-                    bt.logging.info(f"Setting weights: {weights}")
+                    bt.logging.info(f"[blue]Setting weights: {weights}[/blue]")
                     # Update the incentive mechanism on the Bittensor blockchain.
                     result = self.subtensor.set_weights(
                         netuid=self.config.netuid,


### PR DESCRIPTION
- Passes config instead of explicitly passing port in miner
- Makes use of subtensor in doing calls to the chain instead of direct SubstrateInterface
- This also fixes a bug where `subtensor.network` is passed as `local` but the nodes were querying finney due to default
- Fixes bug in validator with `moving_avg` in-case a new neuron joins the network